### PR TITLE
Drop PHP `8.4` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support for `Innmind\Http\Method::query`
+
 ### Changed
 
 - Requires PHP `8.5`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Requires PHP `8.5`
+
 ## 6.0.0 - 2026-02-08
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "issues": "http://github.com/Innmind/Router/issues"
     },
     "require": {
-        "php": "~8.4",
+        "php": "~8.5",
         "innmind/url": "~5.0",
         "innmind/immutable": "~6.0",
         "innmind/http": "~9.0",

--- a/psalm.xml
+++ b/psalm.xml
@@ -14,7 +14,4 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
-    <issueHandlers>
-        <UndefinedAttributeClass errorLevel="suppress" />
-    </issueHandlers>
 </psalm>

--- a/src/Method.php
+++ b/src/Method.php
@@ -25,6 +25,17 @@ final class Method
      * @return Component<mixed, Http\Method>
      */
     #[\NoDiscard]
+    public static function query(): Component
+    {
+        return self::of(Http\Method::query);
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @return Component<mixed, Http\Method>
+     */
+    #[\NoDiscard]
     public static function post(): Component
     {
         return self::of(Http\Method::post);

--- a/src/Pipe.php
+++ b/src/Pipe.php
@@ -36,6 +36,12 @@ final class Pipe
     }
 
     #[\NoDiscard]
+    public function query(): Pipe\Method
+    {
+        return Pipe\Method::of(Method::query());
+    }
+
+    #[\NoDiscard]
     public function post(): Pipe\Method
     {
         return Pipe\Method::of(Method::post());

--- a/src/Pipe/Endpoint.php
+++ b/src/Pipe/Endpoint.php
@@ -78,6 +78,15 @@ final class Endpoint implements Provider
     }
 
     #[\NoDiscard]
+    public function query(): Endpoint\Method
+    {
+        return Endpoint\Method::of(
+            $this->endpoint,
+            Method::query(),
+        );
+    }
+
+    #[\NoDiscard]
     public function post(): Endpoint\Method
     {
         return Endpoint\Method::of(

--- a/src/Pipe/Forward.php
+++ b/src/Pipe/Forward.php
@@ -31,6 +31,12 @@ final class Forward
     }
 
     #[\NoDiscard]
+    public function query(): Forward\Method
+    {
+        return Forward\Method::of(Method::query());
+    }
+
+    #[\NoDiscard]
     public function post(): Forward\Method
     {
         return Forward\Method::of(Method::post());


### PR DESCRIPTION
Since the latest version of `innmind/url` requires `8.5` essentially all packages for `innmind/foundation` can move to `8.5` as well.